### PR TITLE
Only quote keywords in simple unquoted col references

### DIFF
--- a/sql-bricks.js
+++ b/sql-bricks.js
@@ -721,12 +721,20 @@ var reserved = _.object(reserved, reserved);
 
 // handles prefixes before a '.' and suffixes after a ' '
 // for example: 'tbl.order AS tbl_order' -> 'tbl."order" AS tbl_order'
+var unquoted_col_regex = /^[\w\.]+( AS \w+)?$/i;
 function handleColumn(expr, opts) {
   if (expr instanceof Statement)
     return '(' + expr._toString(opts) + ')';
   if (expr instanceof val)
     return handleValue(expr.val, opts);
 
+  if (unquoted_col_regex.test(expr))
+    return quoteReservedColumn(expr)
+  else
+    return expr;
+}
+
+function quoteReservedColumn(expr) {
   var prefix = '';
   var dot_ix = expr.lastIndexOf('.');
   if (dot_ix > -1) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -515,6 +515,10 @@ describe('SQL Bricks', function() {
       check(select('action').from('user'),
         'SELECT "action" FROM user');
     });
+    it('should not quote reserved words in SELECT expressions', function() {
+      check(select("CASE WHEN name = 'Fred' THEN 1 ELSE 0 AS security_level").from('user'),
+        "SELECT CASE WHEN name = 'Fred' THEN 1 ELSE 0 AS security_level FROM user");
+    });
   });
 
   describe('subqueries in <, >, etc', function() {


### PR DESCRIPTION
@schuttsm: Could you review?

The current hyperactive quoting of keywords makes it impossible to use keywords in SELECT statements -- this commit fixes that.
