### PR TITLE
Passing an array to .values() gets serialized into a comma-delimited string

### DIFF
--- a/sql-bricks.js
+++ b/sql-bricks.js
@@ -235,7 +235,7 @@ Insert.prototype.into = function into(tbl, values) {
 };
 Insert.prototype.values = function values() {
   if (this._split_keys_vals_mode) {
-    var args = arguments;
+    var args = argsToArray(arguments);
     _.forEach(_.keys(this._values), function(key, ix) {
       this._values[key] = args[ix];
     }.bind(this));

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -193,6 +193,33 @@ describe('SQL Bricks', function() {
       check(insert().orReplace().into('user').values({'id': 33, 'name': 'Fred'}),
         "INSERT OR REPLACE INTO user (id, name) VALUES (33, 'Fred')");
     });
+    it('should take an object of column/value pairs', function() {
+      check(insert('user', {'id': 33, 'name': 'Fred'}),
+        "INSERT INTO user (id, name) VALUES (33, 'Fred')");
+    });
+    it('should take an array of columns & values', function() {
+      check(insert('user', ['id', 'name']).values([33, 'Fred']),
+        "INSERT INTO user (id, name) VALUES (33, 'Fred')");
+    });
+    it('should take multiple parameters of columns & values', function() {
+      check(insert('user', 'id', 'name').values(33, 'Fred'),
+        "INSERT INTO user (id, name) VALUES (33, 'Fred')");
+    });
+    
+    describe('.into()', function() {
+      it('should take an object of column/value pairs', function() {
+        check(insert().into('user', {'id': 33, 'name': 'Fred'}),
+          "INSERT INTO user (id, name) VALUES (33, 'Fred')");
+      });
+      it('should take an array of columns & values', function() {
+        check(insert().into('user', ['id', 'name']).values([33, 'Fred']),
+          "INSERT INTO user (id, name) VALUES (33, 'Fred')");
+      });
+      it('should take multiple parameters of columns & values', function() {
+        check(insert().into('user', 'id', 'name').values(33, 'Fred'),
+          "INSERT INTO user (id, name) VALUES (33, 'Fred')");
+      });
+    });
   });
 
   describe('SELECT clause', function() {
@@ -249,7 +276,7 @@ describe('SQL Bricks', function() {
     });
   });
 
-  describe('should insert into a new table', function() {
+  describe('select().into() should insert into a new table', function() {
     it('.into()', function() {
       check(select().into('new_user').from('user'),
         'SELECT * INTO new_user FROM user');
@@ -268,7 +295,7 @@ describe('SQL Bricks', function() {
     });
   });
 
-  describe('should insert into a preexisting table', function() {
+  describe('insert().into() should insert into a preexisting table', function() {
     it('insert().into().select()', function() {
       check(insert().into('new_user', 'id', 'addr_id')
         .select('id', 'addr_id').from('user'),


### PR DESCRIPTION
Passing the values as separate arguments works fine:

`insert('user', ['id', 'name']).values(33, 'Fred')`

but passing them as an array:

`insert('user', ['id', 'name']).values([33, 'Fred'])`

resulted in the arguments being .toString()ed into a single string:

`INSERT INTO user (id, name) VALUES ('33,Fred')`

instead of separate values:

`INSERT INTO user (id, name) VALUES (33, 'Fred')`

This is fixed in 81dffa7. /cc @schuttsm

(This bug was found as a result of @dmmalam's question in #11)

I also added 6 tests to the test suite.
