### PR TITLE
Remove unneeded null passing when inserting without explicit values

### DIFF
--- a/sql-bricks.js
+++ b/sql-bricks.js
@@ -244,14 +244,12 @@ Insert.defineClause('columns', function(opts) {
   return '(' + handleColumns(_.keys(this._values[0]), opts) + ')';
 });
 Insert.defineClause('values', function(opts) {
-  var values = _.map(this._values, function(values) {
-    return '(' + handleValues(_.values(values), opts).join(', ') + ')';
-  }).join(', ');
-
   if (this._select)
     return this._select._toString(opts);
   else
-    return 'VALUES ' + values;
+    return 'VALUES ' + _.map(this._values, function(values) {
+      return '(' + handleValues(_.values(values), opts).join(', ') + ')';
+    }).join(', ');
 });
 Insert.defineClause('returning', '{{#if _returning}}RETURNING {{columns _returning}}{{/if}}');
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -429,6 +429,11 @@ describe('SQL Bricks', function() {
         .select('id', 'addr_id').from('user'),
         'INSERT INTO new_user (id, addr_id) SELECT id, addr_id FROM "user"');
     });
+    it('insert().select() with params', function() {
+      check(insert('new_user', 'id', 'addr_id')
+        .select('id', 'addr_id').from('user').where({active: true}).toParams().text,
+        'INSERT INTO new_user (id, addr_id) SELECT id, addr_id FROM "user" WHERE active = $1');
+    });
   });
 
   describe('GROUP BY clause', function() {


### PR DESCRIPTION
Previously `INSERT ... SELECT` queries resulted into wring placeholder numbering.
