### PR TITLE
Fix inherits() for older browsers

### DIFF
--- a/sql-bricks.js
+++ b/sql-bricks.js
@@ -940,10 +940,11 @@
       });
     }
     else {
+      function noop() {};
       noop.prototype = superCtor.prototype;
       ctor.super_ = superCtor;
       ctor.prototype = new noop;
-      ctor.prototype.constructor = superCtor;
+      ctor.prototype.constructor = ctor;
     }
     return ctor;
   }


### PR DESCRIPTION
Looks like your `inherits()` implementation for browsers without `Object.create()` is broken.
